### PR TITLE
Refactor to use optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,9 @@ edition = "2021"
 
 [dependencies]
 futures-util = "0.3.29"
-redis = { version="0.24.0", features=["tokio-comp"] }
+redis = { version="0.24.0", features=["tokio-comp"], optional = true }
 tokio = { version= "1.35.0", features=["full"] }
+
+[features]
+default = []
+event-routing = ["redis"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 [![Rust](https://github.com/josh-tracey/aurora-streams/actions/workflows/rust.yml/badge.svg)](https://github.com/josh-tracey/aurora-streams/actions/workflows/rust.yml)
 
-A Rust library for managing publish-subscribe channels for both Redis and local Tokio messages passing channels.
+A Rust library for managing publish-subscribe channels using Tokio messages passing channels.
+
+optionally event routing can be enabled using redis by passing the `event-routing` feature flag.
+
+this allows pub-sub messages to be shared between multiple services.
 
 ### Features:
 
@@ -32,7 +36,7 @@ use aurora_streams::create_stream;
 #### Create an AuroraStreams instance:
 
 ```rust
-let streams = create_stream("redis://localhost:6379")
+let streams = create_stream()
 ```
 
 #### Create a channel:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@ use aurora::AuroraStreams;
 
 pub mod aurora;
 
-pub fn create_stream(url: &str) -> &'static AuroraStreams {
+pub fn create_stream(#[cfg(feature = "redis")] url: &str) -> &'static AuroraStreams {
+    #[cfg(feature = "redis")]
     let client = redis::Client::open(url).unwrap();
-    let streams = Arc::new(AuroraStreams::new(client));
+    let streams = Arc::new(AuroraStreams::new(
+        #[cfg(feature = "logging")]
+        client,
+    ));
     let a_streams: &'static AuroraStreams = Box::leak(Box::new(streams.clone()));
     a_streams
 }
-


### PR DESCRIPTION
default to use Tokio channels as default pub-sub  channel communcation

optionally support Redis if `event-routing` flag is passed.